### PR TITLE
Исправление README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ REQUIREMENTS
 * hugo >= 0.55
 * Themes
     ```bash
-    git clone https://github.com/alukovenko/kraiklyn.git themes/
+    git clone https://github.com/alukovenko/kraiklyn.git themes/kraiklyn
     ```
 
 # local development


### PR DESCRIPTION
Команда из README скопирует содержимое [репозитория](https://github.com/alukovenko/kraiklyn), в папку themes, hugo так не найдёт тему, содержимое должно быть в `./themes/{themeName}`, следовательно:

```diff
- git clone https://github.com/alukovenko/kraiklyn.git themes/
+ git clone https://github.com/alukovenko/kraiklyn.git themes/kraiklyn
```